### PR TITLE
Ignore URLconf errors when trying to unregister admin models and disable actions 

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -17,13 +17,22 @@ from commitments import admin as commitments_admin
 
 # Unregister some models within some apps from the admin
 from django.contrib import admin
+from django.contrib.admin.sites import NotRegistered
 from basic.blog.models import Category, BlogRoll
 from tagging.models import TaggedItem
-admin.site.unregister(Category)
-admin.site.unregister(BlogRoll)
-admin.site.unregister(TaggedItem)
 
-admin.site.disable_action('delete_selected')
+def unregister(model):
+    try:
+        admin.site.unregister(model)
+    except NotRegistered:
+        pass
+unregister(Category)
+unregister(BlogRoll)
+unregister(TaggedItem)
+try:
+    admin.site.disable_action('delete_selected')
+except KeyError:
+    pass
 
 # Sitemaps
 from basic.blog.sitemap import BlogSitemap


### PR DESCRIPTION
Ignore errors when trying to unregister models and disable actions in the admin from urls.py -- if the models/actions are already unregistered, that's fine.

This patch (or something like it) is needed for me to start up a new localpower site.  Without it, the code raises NotRegistered and KeyError exceptions when I try to access the site.

The exceptions seem to happen because the `urls.py` file is loaded multiple times in a single request.  So the first time it's loaded, the models and actions are successfully unregistered.  All subsequent times, the errors are raised, because they've already been unregistered.

An alternative fix (untested) could be to put these unregistrations in some active app's `admin.py` file (which IIRC is guaranteed to only be loaded once) -- but this patch should be sufficient to ensure that the models/actions are unregistered once and only once.  The only possible downside (besides trivial overhead) is that no loud error will be raised if the models were never registered in the first place -- which might potentially mask deeper configuration problems.
